### PR TITLE
docs(mintlify): scaffold public docs site (introduction → quickstart …

### DIFF
--- a/docs/concepts/dual-model.mdx
+++ b/docs/concepts/dual-model.mdx
@@ -1,0 +1,20 @@
+---
+title: "Dual-model architecture"
+description: "Why Opus reasons and Sonnet executes."
+---
+
+Ghost-hunter uses two Claude models for two different jobs.
+
+## Claude Opus — the reasoner
+
+Opus generates and ranks hypotheses, decides what command to run next, and writes the final root-cause report. Opus is slow and expensive — Ghost-hunter calls it sparingly, only when reasoning is required.
+
+## Claude Sonnet — the executor
+
+Sonnet validates command syntax, compresses raw `gcloud` / `aws` output into structured findings, and answers cheap classification questions ("does this output confirm hypothesis 3?"). Sonnet is fast and cheap — most of the round-trips are Sonnet.
+
+## Why split
+
+A single model would either be too expensive (everything on Opus) or too dumb (everything on Sonnet). The split lets Ghost-hunter spend Opus tokens only where reasoning quality matters and Sonnet tokens everywhere else.
+
+Typical investigation cost: **$0.15–$0.40 in Anthropic API spend**, the bulk of it Opus.

--- a/docs/concepts/focus.mdx
+++ b/docs/concepts/focus.mdx
@@ -1,0 +1,24 @@
+---
+title: "FOCUS 1.0"
+description: "Why Ghost-hunter speaks the FinOps Open Cost & Usage Specification."
+---
+
+Ghost-hunter normalizes both GCP and AWS billing data to [FOCUS 1.0](https://focus.finops.org/), the FinOps Foundation's open billing schema. This is why the same investigation logic works across providers.
+
+## What FOCUS gives us
+
+A common set of column names — `BilledCost`, `EffectiveCost`, `ServiceName`, `ChargeCategory`, `RegionId`, etc — that mean the same thing whether the source is GCP BigQuery export or AWS CUR.
+
+## Mapping
+
+| Provider | Source | Mapping |
+| --- | --- | --- |
+| GCP | BigQuery billing export v1 | Native FOCUS columns where available; computed otherwise. |
+| AWS | Cost & Usage Report (CUR 2.0) | Native FOCUS columns. |
+| AWS | Cost Explorer API | Mapped at runtime from `GetCostAndUsage` response. |
+
+## Why you should care
+
+If you switch clouds (or run multi-cloud), Ghost-hunter's hypotheses transfer. "Egress dominates the bill" reads the same on both. So do the test fixtures — same FOCUS-shaped CSVs, swap the provider flag.
+
+The mapping logic lives in `ghosthunter/billing/focus.py` and is covered by the test suite.

--- a/docs/concepts/severity.mdx
+++ b/docs/concepts/severity.mdx
@@ -1,0 +1,33 @@
+---
+title: "Severity & confidence"
+description: "How Ghost-hunter ranks hypotheses."
+---
+
+Ghost-hunter ranks hypotheses on two axes: **severity** (how much spend the hypothesis explains) and **confidence** (how strongly the evidence supports it).
+
+## Severity
+
+| Level | Meaning |
+| --- | --- |
+| **Critical** | Explains ≥ 50% of the unexpected spend. |
+| **High** | Explains 20–50%. |
+| **Medium** | Explains 5–20%. |
+| **Low** | Explains < 5% but is anomalous. |
+
+Severity is computed from the billing CSV before any LLM call — the LLM does not pick severity.
+
+## Confidence
+
+Confidence bars come from Opus and reflect how much corroborating evidence exists. A hypothesis starts at low confidence and rises as proposed commands return supporting output.
+
+```
+Hypothesis 1: BigQuery on-demand scan blew up    [████████░░] 0.82
+Hypothesis 2: Egress from us-central1 to EU      [████░░░░░░] 0.41
+Hypothesis 3: Idle Cloud SQL replica             [██░░░░░░░░] 0.19
+```
+
+Ghost-hunter stops the loop when one hypothesis crosses **0.85 confidence** or when no hypothesis has improved in three consecutive rounds.
+
+## Why this matters
+
+The dual axis stops Ghost-hunter from chasing a high-confidence-but-low-severity rabbit hole, and stops it from anchoring on a high-severity-but-unsupported guess. The final report leads with the highest-severity hypothesis above the confidence threshold.

--- a/docs/concepts/validator.mdx
+++ b/docs/concepts/validator.mdx
@@ -1,0 +1,46 @@
+---
+title: "The 7-layer validator"
+description: "Why the LLM cannot run anything the allowlist does not permit."
+---
+
+The single most important property of Ghost-hunter is that **the LLM cannot break out of the allowlist**. Safety is enforced in code, not in prompts. Even if Opus is jailbroken, the validator rejects unsafe commands before they execute.
+
+Every proposed command passes through seven layers in order. Any layer can reject. Rejected commands never run — they are returned to the LLM as a structured error so it can propose a different one.
+
+## The seven layers
+
+<Steps>
+  <Step title="1. Shell parse">
+    Tokenize as a POSIX shell command. Reject anything that does not parse cleanly (no shell metacharacters, no command substitution, no pipelines).
+  </Step>
+  <Step title="2. Binary check">
+    The first token must be `gcloud`, `bq`, `aws`, or another explicitly allowlisted binary.
+  </Step>
+  <Step title="3. Subcommand allowlist">
+    The full `binary subcommand` pair must be in the static allowlist (`gcloud compute instances list`, `aws ec2 describe-instances`, etc).
+  </Step>
+  <Step title="4. Flag whitelist">
+    Every flag must be allowlisted for that subcommand. Unknown flags reject.
+  </Step>
+  <Step title="5. Argument shape">
+    Arguments must match the expected shape (e.g. project IDs, ARNs, regions). Free-form strings reject unless explicitly permitted.
+  </Step>
+  <Step title="6. Mutation check">
+    Reject any verb in the rough class of `create`, `delete`, `update`, `set`, `apply`, `enable`, `disable`. Belt-and-braces — the allowlist already excludes these, but the verb check catches new subcommands.
+  </Step>
+  <Step title="7. Cost check">
+    Reject queries with unbounded cost (e.g. `bq query` without a `WHERE` clause that bounds rows scanned).
+  </Step>
+</Steps>
+
+## What this guarantees
+
+- **No mutating action is possible**, even with admin credentials.
+- **No command substitution, no shell injection.** Commands are executed via `subprocess` with `shell=False`.
+- **The LLM cannot bypass the validator.** It is not a tool the LLM can choose to skip — it is the only path to execution.
+
+## Audit
+
+Every accept/reject decision is logged to `~/.ghosthunter/audit.log` with the input command, the layer that decided, and the timestamp. See [audit mode](/modes/audit).
+
+The validator spec is in the repo at `docs/internal/fast-reject-spec.md` and `docs/internal/gcp-allowlist-spec.md`.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -1,0 +1,58 @@
+---
+title: "Installation"
+description: "Pick the install flavor that matches the mode you'll run."
+---
+
+Ghost-hunter is a Python 3.12+ CLI distributed via PyPI. The core install is paranoid-mode only — no cloud SDKs, no credentials, nothing to misconfigure. Active mode pulls provider SDKs as optional extras.
+
+## Core (paranoid mode)
+
+```bash
+pip install ghosthunter
+```
+
+This is the default install. It can read billing CSVs and reason over them — it cannot reach any cloud.
+
+## Active-mode extras
+
+<CodeGroup>
+```bash GCP
+pip install 'ghosthunter[gcp]'
+```
+
+```bash AWS
+pip install 'ghosthunter[aws]'
+```
+
+```bash Both
+pip install 'ghosthunter[all]'
+```
+</CodeGroup>
+
+GCP extras pull `google-cloud-bigquery` and shell out to `gcloud`. AWS extras pull `boto3` for Cost Explorer.
+
+## Verify
+
+```bash
+ghosthunter --version
+ghosthunter doctor
+```
+
+`doctor` checks Python version, Anthropic key presence, and (if installed) cloud SDK reachability.
+
+## Upgrade
+
+```bash
+pip install --upgrade ghosthunter
+```
+
+Ghost-hunter follows semver. Breaking changes ship in major versions only and are flagged in the [CHANGELOG](https://github.com/avinash-matrixgard/ghosthunter/blob/main/CHANGELOG.md).
+
+## Uninstall
+
+```bash
+pip uninstall ghosthunter
+rm -rf ~/.ghosthunter
+```
+
+The second command removes local audit logs and any saved active-mode config.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,55 @@
+---
+title: "Ghost-hunter"
+description: "Investigate why your cloud costs spiked, not just what changed."
+---
+
+Ghost-hunter is a dual-model AI investigator for cloud bills. Claude Opus reasons over hypotheses; Claude Sonnet executes read-only commands and compresses output. A 7-layer command validator enforces safety in code — the LLM cannot run anything the allowlist does not permit.
+
+**Supports GCP and AWS today.** Azure is on the roadmap.
+
+## Three ways to run it
+
+<CardGroup cols={3}>
+  <Card title="Paranoid (default)" icon="shield-halved" href="/modes/paranoid">
+    Zero cloud access. Drop a billing CSV, get hypotheses with confidence bars and proposed commands you run yourself.
+  </Card>
+  <Card title="Active" icon="bolt" href="/modes/active">
+    Read-only GCP or AWS credentials. Ghost-hunter runs `gcloud` or `aws` directly. Sandbox / personal accounts only.
+  </Card>
+  <Card title="Demo" icon="play" href="/modes/demo">
+    Pre-recorded investigation. No API calls, no credentials. For first-look and screenshots.
+  </Card>
+</CardGroup>
+
+## Why Ghost-hunter
+
+Most FinOps tools want admin access and auto-optimize. Ghost-hunter does neither. It is an **investigator**, not an optimizer — built to answer *"why did the bill spike?"*, not *"how do I cut 5%?"*
+
+| | Ghost-hunter | Vantage / CloudHealth / ProsperOps |
+| --- | --- | --- |
+| Access required | None (paranoid mode reads a CSV) | Cross-account IAM role, broad read |
+| Acts on your cloud | Never (read-only by default) | Auto-applies "savings recommendations" |
+| Source code | Open (AGPL-3.0) | Closed SaaS |
+| What it answers | *Why did the bill spike?* | *How can you cut 5%?* |
+| Self-hostable | Yes — billing data never leaves your machine in paranoid mode | No |
+
+## Where to start
+
+<CardGroup cols={2}>
+  <Card title="60-second quickstart" icon="rocket" href="/quickstart">
+    `pip install ghosthunter` and run your first investigation.
+  </Card>
+  <Card title="GCP investigations" icon="google" href="/providers/gcp">
+    BigQuery billing exports, project-level breakdowns, the full GCP path.
+  </Card>
+  <Card title="AWS investigations" icon="aws" href="/providers/aws">
+    Cost Explorer + CUR, AWS-specific allowlist, paranoid-mode CSV path.
+  </Card>
+  <Card title="How the validator works" icon="lock" href="/concepts/validator">
+    7 layers of command checking. Why the LLM can't break out.
+  </Card>
+</CardGroup>
+
+<Note>
+**Looking for adopters.** Ghost-hunter shipped v1.0.6 to PyPI on April 27, 2026. It has been hammered against synthetic billing data and a 1,000+ test suite, but has not yet been run against production cloud accounts at scale. Paranoid mode is risk-free by construction. [Be one of the first 10 reporters](https://github.com/avinash-matrixgard/ghosthunter#-early-adopter-mode--be-the-first-10) and get a free walkthrough with Nash.
+</Note>

--- a/docs/legal/disclaimer.mdx
+++ b/docs/legal/disclaimer.mdx
@@ -1,0 +1,13 @@
+---
+title: "Disclaimer"
+description: "What Ghost-hunter is and isn't."
+---
+
+Ghost-hunter is a **diagnostic tool**, not a finance system, not a compliance system, and not a replacement for your cloud provider's billing console.
+
+- Numbers Ghost-hunter reports come from the billing CSV you provide. If the CSV is wrong, the report is wrong.
+- Ghost-hunter's hypotheses are produced by an LLM. Verify before acting on them.
+- The 7-layer validator dramatically reduces the blast radius of a bad command, but **no software is unbreakable**. Use paranoid mode for production accounts.
+- Ghost-hunter is not affiliated with Google Cloud, Amazon Web Services, or Anthropic. It uses the public APIs and SDKs of each.
+
+For commercial support, retainer-based audits, or custom investigations, see [matrixgard.com](https://matrixgard.com).

--- a/docs/legal/license.mdx
+++ b/docs/legal/license.mdx
@@ -1,0 +1,20 @@
+---
+title: "License (AGPL-3.0)"
+description: "How you can use Ghost-hunter."
+---
+
+Ghost-hunter is licensed under **AGPL-3.0-or-later** as of v1.0.7. Earlier versions (v1.0.0–v1.0.6) were MIT-licensed; that earlier source remains MIT and is preserved in `LICENSE.MIT.original`.
+
+## What AGPL-3.0 means in practice
+
+- **You can use Ghost-hunter freely**, including for commercial work.
+- **If you modify it and offer it as a network service**, you must publish your modifications under AGPL-3.0.
+- **If you use the unmodified CLI as a tool**, you owe nothing — the AGPL trigger is *modification + network service*, not *use*.
+
+## Commercial license
+
+If AGPL-3.0 is incompatible with your distribution model and you'd like a commercial license, email `avinash@matrixgard.com`.
+
+## Full text
+
+The full license text is in [LICENSE](https://github.com/avinash-matrixgard/ghosthunter/blob/main/LICENSE) at the repo root. Relicensing history is in [LICENSE_HISTORY.md](https://github.com/avinash-matrixgard/ghosthunter/blob/main/LICENSE_HISTORY.md).

--- a/docs/legal/trademark.mdx
+++ b/docs/legal/trademark.mdx
@@ -1,0 +1,20 @@
+---
+title: "Trademark"
+description: "Ghost-hunter™ name and logo usage."
+---
+
+**Ghost-hunter™** and the Ghost-hunter logo are trademarks of NASHSMATRIXGARD OPC PVT LTD ("MatrixGard"). The AGPL-3.0 license covers the **code**, not the **name** or **mark**.
+
+## What's allowed
+
+- Saying "I use Ghost-hunter" / "powered by Ghost-hunter" in good faith.
+- Linking to [github.com/avinash-matrixgard/ghosthunter](https://github.com/avinash-matrixgard/ghosthunter) or [matrixgard.com](https://matrixgard.com).
+- Forks for personal use, named clearly so they aren't confused with the upstream.
+
+## What's not allowed
+
+- Distributing modified Ghost-hunter as **"Ghost-hunter"** (rename your fork).
+- Using the Ghost-hunter mark in a product name, logo, or domain you control.
+- Implying MatrixGard endorses your fork or service.
+
+Full policy: [TRADEMARK.md](https://github.com/avinash-matrixgard/ghosthunter/blob/main/TRADEMARK.md).

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://mintlify.com/schema.json",
+  "name": "Ghost-hunter",
+  "logo": {
+    "light": "/logo/light.svg",
+    "dark": "/logo/dark.svg",
+    "href": "https://matrixgard.com"
+  },
+  "favicon": "/favicon.png",
+  "colors": {
+    "primary": "#FF7A1A",
+    "light": "#FFA15C",
+    "dark": "#262726",
+    "background": {
+      "light": "#FFFFFF",
+      "dark": "#1A1A1A"
+    }
+  },
+  "topbarLinks": [
+    {
+      "name": "GitHub",
+      "url": "https://github.com/avinash-matrixgard/ghosthunter"
+    }
+  ],
+  "topbarCtaButton": {
+    "name": "Free audit",
+    "url": "https://matrixgard.com/?checklist=open"
+  },
+  "anchors": [
+    {
+      "name": "PyPI",
+      "icon": "python",
+      "url": "https://pypi.org/project/ghosthunter/"
+    },
+    {
+      "name": "Issues",
+      "icon": "bug",
+      "url": "https://github.com/avinash-matrixgard/ghosthunter/issues"
+    },
+    {
+      "name": "MatrixGard",
+      "icon": "shield-halved",
+      "url": "https://matrixgard.com"
+    }
+  ],
+  "navigation": [
+    {
+      "group": "Get Started",
+      "pages": [
+        "introduction",
+        "quickstart",
+        "installation"
+      ]
+    },
+    {
+      "group": "Modes",
+      "pages": [
+        "modes/paranoid",
+        "modes/active",
+        "modes/demo",
+        "modes/audit"
+      ]
+    },
+    {
+      "group": "Providers",
+      "pages": [
+        "providers/gcp",
+        "providers/aws"
+      ]
+    },
+    {
+      "group": "Concepts",
+      "pages": [
+        "concepts/dual-model",
+        "concepts/validator",
+        "concepts/severity",
+        "concepts/focus"
+      ]
+    },
+    {
+      "group": "Legal",
+      "pages": [
+        "legal/license",
+        "legal/trademark",
+        "legal/disclaimer"
+      ]
+    }
+  ],
+  "footerSocials": {
+    "github": "https://github.com/avinash-matrixgard/ghosthunter",
+    "linkedin": "https://www.linkedin.com/company/matrixgard",
+    "website": "https://matrixgard.com"
+  }
+}

--- a/docs/modes/active.mdx
+++ b/docs/modes/active.mdx
@@ -1,0 +1,46 @@
+---
+title: "Active mode"
+description: "Read-only credentials. Ghost-hunter runs the commands itself."
+---
+
+<Warning>
+Active mode is for **sandbox and personal accounts only**. For production, use [paranoid mode](/modes/paranoid).
+</Warning>
+
+In active mode, Ghost-hunter runs `gcloud` or `aws` directly using read-only credentials you provide. The 7-layer validator still gates every command — the LLM cannot escape the allowlist.
+
+## Setup
+
+```bash
+pip install 'ghosthunter[gcp]'   # or [aws] or [all]
+```
+
+Drop a config at `~/.ghosthunter/config.toml`:
+
+```toml
+[provider.gcp]
+project_id = "my-sandbox-project"
+billing_export_table = "my-billing.gcp_billing_export_v1_0123"
+
+[provider.aws]
+profile = "ghosthunter-readonly"
+region  = "us-east-1"
+```
+
+Authenticate the underlying SDKs the normal way (`gcloud auth application-default login`, `aws sso login`, etc).
+
+## Run
+
+```bash
+ghosthunter investigate --active --provider gcp
+```
+
+Ghost-hunter will execute each proposed command itself, capture the output, compress it via Sonnet, and continue the loop without you pasting.
+
+## What active mode cannot do
+
+Even with credentials, the validator blocks anything that isn't a read-only `describe` / `get` / `list` / `query` operation. There is no flag to disable the validator. If you want a command that isn't in the allowlist, open an issue.
+
+## Audit log
+
+Every command Ghost-hunter runs in active mode is appended to `~/.ghosthunter/audit.log`. See [audit mode](/modes/audit) to review past investigations.

--- a/docs/modes/audit.mdx
+++ b/docs/modes/audit.mdx
@@ -1,0 +1,18 @@
+---
+title: "Audit mode"
+description: "Review past investigations from the local audit log."
+---
+
+Every investigation Ghost-hunter runs in active mode appends to `~/.ghosthunter/audit.log`. Audit mode replays them.
+
+```bash
+ghosthunter audit               # list past investigations
+ghosthunter audit --id 42       # replay one
+ghosthunter audit --since 7d    # last week
+```
+
+Each entry records: timestamp, mode, provider, the full command sequence, hypotheses considered, and the final root-cause report. Nothing is sent over the network.
+
+## Rotation
+
+The audit log is plain JSONL. Rotate it with logrotate, ship it to your SIEM, or delete it — Ghost-hunter does not depend on log retention for correctness.

--- a/docs/modes/demo.mdx
+++ b/docs/modes/demo.mdx
@@ -1,0 +1,15 @@
+---
+title: "Demo mode"
+description: "Pre-recorded investigation. Zero credentials, zero API calls."
+---
+
+Demo mode replays a baked-in investigation against synthetic billing data. No Anthropic key, no cloud SDK, no network.
+
+```bash
+ghosthunter demo --provider gcp
+ghosthunter demo --provider aws
+```
+
+Use this for first-look, screenshots, conference talks, or any environment where you can't make outbound API calls.
+
+The demo data ships inside the package at `ghosthunter/sample_data/` and is the same data used by the test suite, so what you see is exactly what's covered by tests.

--- a/docs/modes/paranoid.mdx
+++ b/docs/modes/paranoid.mdx
@@ -1,0 +1,44 @@
+---
+title: "Paranoid mode"
+description: "The default. Zero cloud access. You stay in control."
+---
+
+Paranoid mode is Ghost-hunter's default. It never touches your cloud — it reads a billing CSV from your local disk, asks Claude Opus for hypotheses, prints the read-only commands that would confirm each one, and waits for you to paste output back.
+
+**Blast radius: zero.** Even if the LLM goes off the rails, it cannot run anything on your infrastructure.
+
+## When to use
+
+- Production accounts (the only safe choice).
+- Any cloud where you do not personally hold the credentials.
+- Compliance-sensitive environments — billing data never leaves your machine except as prompts to Anthropic.
+
+## The loop
+
+<Steps>
+  <Step title="You export billing data">
+    A CSV from BigQuery (GCP) or Cost Explorer / CUR (AWS).
+  </Step>
+  <Step title="Ghost-hunter reasons">
+    Opus generates ranked hypotheses with confidence bars based on the CSV.
+  </Step>
+  <Step title="Ghost-hunter proposes a command">
+    A single read-only `gcloud` or `aws` command, validated by the [7-layer allowlist](/concepts/validator).
+  </Step>
+  <Step title="You run it">
+    Paste the output back into the prompt. Ghost-hunter compresses it via Sonnet and updates the hypothesis ranking.
+  </Step>
+  <Step title="Repeat until root-caused">
+    Loop until Opus is confident in a single hypothesis, then it produces a final report.
+  </Step>
+</Steps>
+
+## What leaves your machine
+
+Only the prompts sent to Anthropic. Your billing CSV is parsed locally; only the relevant excerpts are included in prompts. No cloud calls, no telemetry to MatrixGard, no third-party services.
+
+## Demo
+
+<Frame>
+  <img src="https://raw.githubusercontent.com/avinash-matrixgard/ghosthunter/main/docs/demo-paranoid-aws.gif" alt="Ghost-hunter paranoid mode on AWS" />
+</Frame>

--- a/docs/providers/aws.mdx
+++ b/docs/providers/aws.mdx
@@ -1,0 +1,41 @@
+---
+title: "Amazon Web Services (AWS)"
+description: "Cost Explorer + CUR with read-only IAM."
+---
+
+AWS support shipped in v1.0.6. Investigations run against either Cost Explorer (`ce:GetCostAndUsage`) or a Cost & Usage Report (CUR) export.
+
+## Export billing data
+
+**Option A — Cost & Usage Report (recommended for paranoid mode).**
+
+1. Billing console → **Cost & Usage Reports** → Create new report.
+2. Choose hourly granularity, FOCUS-1.0-compatible columns, Parquet or CSV.
+3. Pick an S3 bucket — Ghost-hunter does not need access to it.
+4. Wait 24h, download the latest CSV slice.
+
+```bash
+ghosthunter investigate --csv cur-2026-04.csv --provider aws
+```
+
+**Option B — Cost Explorer (active mode only).** Requires `ce:GetCostAndUsage` on a read-only IAM role.
+
+## Active mode
+
+```toml
+# ~/.ghosthunter/config.toml
+[provider.aws]
+profile = "ghosthunter-readonly"
+region  = "us-east-1"
+```
+
+Minimum IAM policy: `ce:GetCostAndUsage`, `ec2:Describe*`, `s3:ListAllMyBuckets`, `rds:Describe*`, `cloudwatch:GetMetric*`. Full policy in the repo at `docs/internal/aws-iam-policy.json`.
+
+```bash
+aws sso login --profile ghosthunter-readonly
+ghosthunter investigate --active --provider aws
+```
+
+## Allowlisted commands
+
+Read-only `aws ec2 describe-*`, `aws s3 ls`, `aws rds describe-*`, `aws cloudwatch get-metric-*`, `aws ce get-*`. The validator rejects anything mutating, even with admin credentials.

--- a/docs/providers/gcp.mdx
+++ b/docs/providers/gcp.mdx
@@ -1,0 +1,52 @@
+---
+title: "Google Cloud (GCP)"
+description: "BigQuery billing exports + gcloud read-only commands."
+---
+
+GCP is the original Ghost-hunter target. Investigations work against the FOCUS-1.0-aligned BigQuery billing export.
+
+## Export billing data
+
+If you don't already have a BigQuery billing export configured:
+
+1. Console → Billing → **Billing export** → BigQuery export.
+2. Create a dataset (typically `billing_export`).
+3. Wait 24h for the first row to land.
+
+For paranoid mode, dump a slice to CSV:
+
+```sql
+EXPORT DATA OPTIONS(
+  uri='gs://your-bucket/ghosthunter/billing-*.csv',
+  format='CSV',
+  overwrite=true,
+  header=true
+) AS
+SELECT *
+FROM `your-project.billing_export.gcp_billing_export_v1_0123`
+WHERE DATE(usage_start_time) BETWEEN '2026-04-01' AND '2026-04-29';
+```
+
+Then download and run:
+
+```bash
+ghosthunter investigate --csv billing-000000000000.csv --provider gcp
+```
+
+## Active mode
+
+```toml
+# ~/.ghosthunter/config.toml
+[provider.gcp]
+project_id = "my-sandbox"
+billing_export_table = "my-billing.gcp_billing_export_v1_0123"
+```
+
+```bash
+gcloud auth application-default login
+ghosthunter investigate --active --provider gcp
+```
+
+## Allowlisted commands
+
+The GCP allowlist covers `gcloud compute`, `gcloud run`, `gcloud sql`, `gcloud storage`, `gcloud logging`, and read-only `bq query` patterns. Full spec at [docs/internal/gcp-allowlist-spec.md](https://github.com/avinash-matrixgard/ghosthunter/blob/main/docs/internal/gcp-allowlist-spec.md) in the repo.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,53 @@
+---
+title: "Quickstart"
+description: "From zero to your first investigation in 60 seconds."
+---
+
+<Steps>
+  <Step title="Install">
+    ```bash
+    pip install ghosthunter
+    ```
+    Requires Python 3.12+. The core install is paranoid-mode only — no cloud SDKs.
+  </Step>
+
+  <Step title="Set your Anthropic API key">
+    ```bash
+    export ANTHROPIC_API_KEY=sk-ant-...
+    ```
+    Ghost-hunter calls Claude Opus and Sonnet directly. You bring the key.
+  </Step>
+
+  <Step title="Export your billing data">
+    Drop a billing CSV from your cloud's billing console into the working directory. See the provider guides for exact export steps:
+
+    - [GCP — BigQuery billing export](/providers/gcp)
+    - [AWS — Cost Explorer or CUR](/providers/aws)
+  </Step>
+
+  <Step title="Investigate">
+    ```bash
+    ghosthunter investigate --csv billing.csv
+    ```
+    Ghost-hunter reads the CSV locally, asks Opus for hypotheses, prints proposed read-only commands, and waits for you to paste output back. **Nothing leaves your machine except the prompts to Anthropic.**
+  </Step>
+</Steps>
+
+## What you get
+
+A ranked list of hypotheses with confidence bars, the read-only commands that would confirm each one, and a final root-cause report you can hand to your finance team.
+
+<Frame>
+  <img src="https://raw.githubusercontent.com/avinash-matrixgard/ghosthunter/main/docs/demo-paranoid-gcp.gif" alt="Ghost-hunter investigating a GCP cost spike in paranoid mode" />
+</Frame>
+
+## Next
+
+<CardGroup cols={2}>
+  <Card title="Understand paranoid mode" icon="shield-halved" href="/modes/paranoid">
+    Why the default is zero-cloud-access and how the human-in-the-loop loop works.
+  </Card>
+  <Card title="Run with live credentials" icon="bolt" href="/modes/active">
+    Active mode for sandbox and personal accounts.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
…→ modes/providers/concepts/legal)

17 MDX pages + mint.json mirroring the docs.aiactradar.com structure: Get Started · Modes (paranoid/active/demo/audit) · Providers (GCP/AWS) · Concepts (dual-model/validator/severity/FOCUS) · Legal (license/trademark/disclaimer).

Ready to deploy via Mintlify GitHub app — no build step, content is the deployment.

<!--
Thanks for the contribution. A few quick checks below.
Anything you can't fill in yet, leave as-is and we'll work on it together.
-->

## What

<!-- One-paragraph summary of what this PR changes -->

## Why

<!-- Link to the issue / discussion / external context that motivated the change -->

Fixes #

## Type of change

- [ ] New provider / mode / control surface
- [ ] Bug fix (non-breaking)
- [ ] Bug fix (breaking — CLI flags or config schema changed)
- [ ] Refactor (no behavior change)
- [ ] Documentation only
- [ ] Tests / fixtures
- [ ] CI / tooling

## Security review (mandatory for command-validation changes)

If this PR touches the command validator, allowlist, fast-reject layer, or anything that decides whether a proposed command runs:

- [ ] I added test cases covering the new behavior
- [ ] I added at least one negative test case (something that MUST be rejected)
- [ ] I did NOT relax any existing fast-reject pattern (or if I did, the rationale is explained below)
- [ ] I did NOT add a "soft override" / "ignore validator if user confirms" path

## Checklist

- [ ] `ruff check` is clean
- [ ] `ruff format` is clean
- [ ] `pytest` passes locally on Python 3.12
- [ ] If a new dep was added, it's a deliberate choice and the README's stack section is updated
- [ ] If a new CLI flag was added, README usage section is updated
- [ ] CHANGELOG.md "Unreleased" section updated
- [ ] No secrets, no real account IDs, no real billing data committed
- [ ] If GitHub Actions were added/updated: pinned to a commit SHA, not a version tag

## Tested with

- Python:
- OS:
- Provider (gcp / aws / billing-file):
- Mode (paranoid / active / demo / audit):

## Sample output / screenshots

<!-- Paste a redacted CLI session or screenshot showing the new behavior -->
