### PR TITLE
security(pipes): block awk entirely (closes #4, v1.0.7)

### DIFF
--- a/src/ghosthunter/providers/aws.py
+++ b/src/ghosthunter/providers/aws.py
@@ -493,7 +493,7 @@ AWS_REASONER_RULES = """## COMMAND RULES (AWS — NON-NEGOTIABLE — security la
 
 1. ONE command per turn. NEVER chain with `&&`, `;`, or `||`.
 2. Only safe pipes: `head`, `tail`, `wc`, `sort`, `uniq`, `grep`, `cut`,
-   `awk`, `tr`, `jq`. Anything else gets blocked.
+   `tr`, `jq`. Anything else gets blocked.
 3. CLI is `aws` only. Read-only verbs: `describe-*`, `list-*`, `get-*`.
    FORBIDDEN verbs (blocked by security layer):
      create-, delete-, update-, modify-, put-, start-, run-, terminate-,

--- a/src/ghosthunter/providers/gcp.py
+++ b/src/ghosthunter/providers/gcp.py
@@ -306,7 +306,7 @@ GCP_REASONER_RULES = """## COMMAND RULES (NON-NEGOTIABLE — security layers wil
 
 1. ONE command per turn. NEVER chain with `&&`, `;`, or `||`.
 2. Only safe pipes: `head`, `tail`, `wc`, `sort`, `uniq`, `grep`, `cut`,
-   `awk`, `tr`, `jq`. Anything else gets blocked.
+   `tr`, `jq`. Anything else gets blocked.
 3. Read-only only: gcloud, bq, gsutil. No `delete`, `create`, `update`,
    `set-iam-policy`, etc. The security layer will reject destructive verbs.
 4. `bq query` must be SELECT only.

--- a/src/ghosthunter/security/pipes.py
+++ b/src/ghosthunter/security/pipes.py
@@ -14,7 +14,11 @@ SAFE_PIPE_TARGETS: list[str] = [
     r"^tail(\s+-?\d+)?$",
     r"^grep(\s+-[ivEclnH]+)?(\s+.+)?$",
     r"^cut(\s+.+)?$",
-    r"^awk(\s+.+)?$",
+    # awk REMOVED in v1.0.7 — the previous pattern `^awk(\s+.+)?$` accepted
+    # any awk arguments, which left awk's `system()`, `getline`, and `exec()`
+    # builtins reachable in theory. The Apr 29 2026 audit flagged this as a
+    # theoretical-severity gap. Nothing in our investigator paths needs awk;
+    # grep/cut/jq cover the legitimate use cases. See ghosthunter#4.
     r"^tr(\s+.+)?$",
     r"^jq(\s+-[rsc]+)?(\s+.+)?$",
 ]
@@ -23,6 +27,10 @@ _COMPILED = [re.compile(p) for p in SAFE_PIPE_TARGETS]
 
 # Explicitly forbidden pipe targets — listed for clarity even though
 # anything not in SAFE_PIPE_TARGETS is rejected by default.
+#
+# `awk` is in this set as of v1.0.7. Belt-and-braces: even if a future
+# contributor re-adds an awk pattern to SAFE_PIPE_TARGETS, the blocklist
+# check in validate_pipes() runs first and catches it.
 BLOCKED_PIPE_TARGETS = {
     "curl",
     "wget",
@@ -42,6 +50,7 @@ BLOCKED_PIPE_TARGETS = {
     "ssh",
     "scp",
     "eval",
+    "awk",
 }
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -291,6 +291,39 @@ class TestPipeValidation:
     def test_blocks_python_pipe(self, validator):
         assert not validator.is_allowed("gcloud compute instances list | python").allowed
 
+    # awk family — added in v1.0.7 per ghosthunter#4 (Apr 29 2026 audit).
+    # Previously `^awk(\s+.+)?$` accepted awk with any args, which left
+    # awk's `system()` / `getline` / `exec()` builtins reachable in theory.
+    # Since v1.0.7 awk is in BLOCKED_PIPE_TARGETS — closes the entire
+    # surface in one move.
+    def test_blocks_plain_awk_pipe(self, validator):
+        assert not validator.is_allowed(
+            "gcloud compute instances list | awk '{print $1}'"
+        ).allowed
+
+    def test_blocks_awk_system_call(self, validator):
+        # The audit-flagged shape: awk shelling out via system().
+        assert not validator.is_allowed(
+            "gcloud logging read 'x' | awk 'BEGIN{system(\"env\")}'"
+        ).allowed
+
+    def test_blocks_awk_getline_command(self, validator):
+        # awk's `getline` can read from external commands — also blocked.
+        assert not validator.is_allowed(
+            "gcloud compute instances list | awk '{cmd=\"ls\"; cmd | getline line}'"
+        ).allowed
+
+    def test_blocks_awk_exec_call(self, validator):
+        assert not validator.is_allowed(
+            "gcloud compute instances list | awk 'BEGIN{exec(\"cat\")}'"
+        ).allowed
+
+    def test_blocks_bare_awk(self, validator):
+        # Even bare `awk` — no exception for the simplest form.
+        assert not validator.is_allowed(
+            "gcloud compute instances list | awk"
+        ).allowed
+
 
 # ---------------------------------------------------------------------------
 # Layer 4: bq query SELECT-only enforcement

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -297,9 +297,7 @@ class TestPipeValidation:
     # Since v1.0.7 awk is in BLOCKED_PIPE_TARGETS — closes the entire
     # surface in one move.
     def test_blocks_plain_awk_pipe(self, validator):
-        assert not validator.is_allowed(
-            "gcloud compute instances list | awk '{print $1}'"
-        ).allowed
+        assert not validator.is_allowed("gcloud compute instances list | awk '{print $1}'").allowed
 
     def test_blocks_awk_system_call(self, validator):
         # The audit-flagged shape: awk shelling out via system().
@@ -320,9 +318,7 @@ class TestPipeValidation:
 
     def test_blocks_bare_awk(self, validator):
         # Even bare `awk` — no exception for the simplest form.
-        assert not validator.is_allowed(
-            "gcloud compute instances list | awk"
-        ).allowed
+        assert not validator.is_allowed("gcloud compute instances list | awk").allowed
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4.

Per the Apr 29 audit's Option A recommendation, removes awk from `SAFE_PIPE_TARGETS` and adds it to `BLOCKED_PIPE_TARGETS` (belt-and-braces). Updates GCP/AWS reasoner prompts so the LLM doesn't propose awk pipes that get rejected. 5 new tests cover the audit-flagged attack shapes (system, getline, exec) plus plain awk and bare awk.

**Verification:**
- `pytest tests/test_security.py -k 'awk or pipe'` → 17 passed
- `pytest tests/` → 1200 passed
- `ruff check` → all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)