### PR TITLE
security(secrets): redact credentials before disk write + purge-history CLI (closes #3, v1.0.7)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -135,9 +135,26 @@ please report it.
    - `~/.ghosthunter/palace/` — if memory palace is enabled,
      conclusions are indexed.
 
-   No automatic redaction is performed. Delete these files (or the
-   relevant entries) if you're concerned. Redacting your pastes
-   before handing them to Ghosthunter is the current mitigation.
+   **Mitigation in v1.0.7:** automatic redaction now runs on the
+   audit-log writer and the memory palace's `remember()` path before
+   any disk write. Pattern-matched credential shapes (AWS access
+   keys, GitHub tokens, Anthropic / OpenAI keys, JWTs, Bearer tokens,
+   generic auth headers, PEM private key blocks, GCP service account
+   private_key fields) are replaced with `[REDACTED:<type>]`
+   placeholders. See `ghosthunter/security/secrets_redactor.py` for
+   the full pattern set.
+
+   Pattern-based redaction is **best-effort, not exhaustive** — a
+   credential format we haven't seen will pass through. The chat
+   history file (`~/.ghosthunter/chat_history`) is currently NOT
+   redacted on write — prompt_toolkit owns that file and our hook
+   doesn't sit on its write path. Backups, Time Machine, and cloud
+   sync still propagate whatever lands on disk.
+
+   **For history written by v1.0.6 or earlier**, run
+   `ghosthunter purge-history` to wipe the chat_history file, the
+   audit log, and the palace storage. Configuration files are
+   preserved. The `--yes` / `-y` flag skips the confirmation prompt.
 
 3. **Social engineering.** A malicious party convincing you to paste
    specific output or install a specific billing file is outside the

--- a/src/ghosthunter/cli.py
+++ b/src/ghosthunter/cli.py
@@ -47,6 +47,7 @@ from ghosthunter.providers.billing_file import (
     load_spikes_from_files,
 )
 from ghosthunter.providers.gcp import GCPProvider
+from ghosthunter.security.secrets_redactor import redact_dict
 from ghosthunter.security.validator import SecurityValidator
 from ghosthunter.ui import render_command_blocked
 
@@ -946,6 +947,65 @@ def audit(
     console.print(_build_audit_table(lines[-limit:]))
 
 
+@app.command(name="purge-history")
+def purge_history(
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+) -> None:
+    """Wipe local Ghost-hunter history (chat history, audit log, palace).
+
+    Use this if you ran v1.0.6 or earlier, pasted command output that may
+    have contained secrets, and want to remove that history from disk. The
+    on-disk redaction layer was added in v1.0.7 (ghosthunter#3) — older
+    history was written without redaction and may contain plaintext
+    credentials.
+
+    Removes:
+      - ~/.ghosthunter/chat_history       (prompt_toolkit line history)
+      - ~/.ghosthunter/audit.log          (investigation outcome ledger)
+      - ~/.ghosthunter/palace/            (memory palace storage, if present)
+
+    Configuration files (config.toml) are NOT removed.
+    """
+    from pathlib import Path
+
+    home = Path.home() / ".ghosthunter"
+    targets: list[tuple[str, Path]] = [
+        ("chat_history", home / "chat_history"),
+        ("audit.log", home / "audit.log"),
+        ("palace/", home / "palace"),
+    ]
+    existing = [(label, path) for label, path in targets if path.exists()]
+
+    if not existing:
+        console.print("[green]Nothing to purge.[/green] No history files found.")
+        raise typer.Exit(0)
+
+    console.print("[yellow]The following will be permanently deleted:[/yellow]")
+    for label, path in existing:
+        console.print(f"  • {path}  ({label})")
+
+    if not yes:
+        confirm = typer.confirm("\nProceed with deletion?", default=False)
+        if not confirm:
+            console.print("[dim]Aborted.[/dim]")
+            raise typer.Exit(0)
+
+    import shutil
+
+    for label, path in existing:
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+            console.print(f"  [green]✓[/green] removed {label}")
+        except Exception as exc:
+            console.print(f"  [red]✗[/red] failed to remove {label}: {exc}")
+            raise typer.Exit(1) from exc
+
+    console.print("\n[green]Purge complete.[/green]")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1387,6 +1447,14 @@ def _render_recommendations(items: list) -> None:
 
 
 def _append_audit_log(result, extra: dict | None = None) -> None:
+    """Append an investigation outcome to ~/.ghosthunter/audit.log.
+
+    All string values pass through ``redact_secrets`` before disk write
+    (per ghosthunter#3, Apr 29 2026 audit). Conclusion text from Opus may
+    quote command-output snippets; if a user pasted billing-related output
+    that included a Bearer token or AWS access key, the audit log would
+    otherwise persist it forever.
+    """
     AUDIT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     entry = {
         "timestamp": datetime.now().isoformat(timespec="seconds"),
@@ -1398,8 +1466,11 @@ def _append_audit_log(result, extra: dict | None = None) -> None:
     }
     if extra:
         entry.update(extra)
+
+    redacted_entry, _redaction_counts = redact_dict(entry)
+
     with AUDIT_LOG_PATH.open("a") as f:
-        f.write(json.dumps(entry) + "\n")
+        f.write(json.dumps(redacted_entry) + "\n")
 
 
 if __name__ == "__main__":

--- a/src/ghosthunter/memory/palace.py
+++ b/src/ghosthunter/memory/palace.py
@@ -272,9 +272,20 @@ class PalaceClient:
         hall: str = "facts",
         source: str | None = None,
     ) -> bool:
-        """Store a memory. Returns True on success, False if no-op/failure."""
+        """Store a memory. Returns True on success, False if no-op/failure.
+
+        ``content`` passes through the secrets redactor before storage
+        (per ghosthunter#3, Apr 29 2026 audit). Palace memories are
+        long-lived and replayed across investigations — a leaked token
+        in a stored conclusion would persist indefinitely otherwise.
+        """
         if not is_available() or not content.strip():
             return False
+        # Lazy import keeps the security module out of the palace's
+        # critical-path init.
+        from ghosthunter.security.secrets_redactor import redact_secrets
+
+        content = redact_secrets(content).redacted
         try:
             return asyncio.run(self._remember_once(content, wing, room, hall, source))
         except Exception:

--- a/src/ghosthunter/security/secrets_redactor.py
+++ b/src/ghosthunter/security/secrets_redactor.py
@@ -1,0 +1,169 @@
+"""Layer 5: secrets redaction before any disk write.
+
+Pasted command output may contain credentials. Without redaction, those
+secrets land unredacted in:
+
+  - ``~/.ghosthunter/audit.log`` — investigation outcomes (Opus's evidence
+    summary may quote stdout snippets containing tokens).
+  - The memory palace — conclusions stored for cross-session recall may
+    include sensitive context.
+  - Any future on-disk artifact a Ghost-hunter component writes.
+
+Backups, Time Machine, cloud sync (Dropbox / iCloud) propagate the leak.
+The user's mental model in paranoid mode is "Ghost-hunter is read-only and
+safe — I can paste freely" — so we have to make that assumption true at
+the disk-write layer.
+
+Added in v1.0.7 per ghosthunter#3 (Apr 29 2026 audit, the only release-
+blocking finding among four documented gaps).
+
+Patterns target high-confidence credential shapes only. False positives
+on normal billing data and command output are unacceptable in this
+module — we redact what we're sure is a secret, not what *might be* one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+# Each pattern: (label, regex, replacement_fn).
+# replacement_fn receives the match object so we can preserve the
+# secret type in the redaction (helpful for debugging without leaking
+# the value itself).
+SECRET_PATTERNS: list[tuple[str, re.Pattern[str], str]] = [
+    # AWS access keys — public format, deterministic prefix.
+    ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "[REDACTED:aws_access_key]"),
+    ("aws_temp_access_key", re.compile(r"\bASIA[0-9A-Z]{16}\b"), "[REDACTED:aws_temp_access_key]"),
+    # GitHub PAT / app tokens — well-defined prefixes, fixed length.
+    ("github_token", re.compile(r"\bgh[psru]_[A-Za-z0-9]{36,}\b"), "[REDACTED:github_token]"),
+    # Anthropic API keys — `sk-ant-` prefix.
+    ("anthropic_key", re.compile(r"\bsk-ant-[A-Za-z0-9_\-]{20,}\b"), "[REDACTED:anthropic_key]"),
+    # OpenAI API keys — `sk-` followed by 48 chars of base62.
+    ("openai_key", re.compile(r"\bsk-[A-Za-z0-9]{48}\b"), "[REDACTED:openai_key]"),
+    # JWT-shape tokens (3 base64url segments, dot-separated).
+    # Note: must come BEFORE bearer_token to win the race on `Bearer eyJ...`.
+    (
+        "jwt",
+        re.compile(r"\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\b"),
+        "[REDACTED:jwt]",
+    ),
+    # Bearer tokens in Authorization headers — capture everything until
+    # whitespace, comma, or quote.
+    (
+        "bearer_token",
+        re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=\-]{16,}"),
+        "[REDACTED:bearer_token]",
+    ),
+    # Generic Authorization / api-key headers. Handles three common forms:
+    #   - shell:    api_key=longvalue
+    #   - http:     Authorization: longvalue
+    #   - json:     "x-api-key": "longvalue"
+    # The closing-quote-on-key is what JSON requires; the optional quote on
+    # the value covers shell, JSON, and YAML.
+    (
+        "auth_header",
+        re.compile(
+            r"""(?ix)
+            \b(authorization|api[_-]?key|x-api-key)['\"]?
+            \s*[:=]\s*
+            ['\"]?[A-Za-z0-9._~+/=\-]{12,}['\"]?
+            """
+        ),
+        "[REDACTED:auth_header]",
+    ),
+    # GCP service account JSON — match a private key block specifically
+    # (the most sensitive part). The full SA JSON contains email + project
+    # ID which are not secret on their own; the private_key field is what
+    # matters.
+    #
+    # `[A-Z ]*` (zero-or-more) handles BOTH shapes:
+    #   "-----BEGIN PRIVATE KEY-----"      (PKCS#8 — GCP default)
+    #   "-----BEGIN RSA PRIVATE KEY-----"  (PKCS#1 — older AWS / generated)
+    (
+        "gcp_private_key",
+        re.compile(
+            r'"private_key"\s*:\s*"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----\\n?"',
+        ),
+        '"private_key":"[REDACTED:gcp_private_key]"',
+    ),
+    # PEM-armored private keys anywhere in text — same zero-or-more allowance
+    # for the algorithm tag.
+    (
+        "pem_private_key",
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----",
+        ),
+        "[REDACTED:pem_private_key]",
+    ),
+]
+
+
+@dataclass(frozen=True)
+class RedactionResult:
+    """Output of redact_secrets: cleaned text + per-pattern hit counts."""
+
+    redacted: str
+    redactions_by_pattern: dict[str, int]
+
+    @property
+    def total_redactions(self) -> int:
+        return sum(self.redactions_by_pattern.values())
+
+    @property
+    def had_redactions(self) -> bool:
+        return self.total_redactions > 0
+
+
+def redact_secrets(text: str) -> RedactionResult:
+    """Strip credential-shaped substrings from text.
+
+    Idempotent and safe to call on text that contains no secrets — returns
+    the original text with zero redactions. The function applies patterns
+    in registration order; the JWT pattern intentionally fires before the
+    bearer pattern so a `Bearer eyJ...` header gets the more specific
+    redaction label first.
+    """
+    if not text:
+        return RedactionResult(redacted=text, redactions_by_pattern={})
+
+    redactions: dict[str, int] = {}
+    redacted = text
+    for name, pattern, replacement in SECRET_PATTERNS:
+        redacted, count = pattern.subn(replacement, redacted)
+        if count > 0:
+            redactions[name] = count
+    return RedactionResult(redacted=redacted, redactions_by_pattern=redactions)
+
+
+def redact_dict(data: dict[str, Any]) -> tuple[dict[str, Any], dict[str, int]]:
+    """Recursively redact secrets in a dict's string values.
+
+    Used by the audit-log writer: an audit entry's `conclusion` field can
+    contain stdout snippets quoted by Opus. We walk every string value
+    and apply redact_secrets.
+
+    Non-string scalars (ints, bools, None) and nested structures are
+    walked but not modified except where they contain strings.
+
+    Returns a fresh dict (does NOT mutate the input) plus aggregate
+    redaction counts across all values.
+    """
+    counts: dict[str, int] = {}
+
+    def _walk(value: Any) -> Any:
+        if isinstance(value, str):
+            r = redact_secrets(value)
+            for k, v in r.redactions_by_pattern.items():
+                counts[k] = counts.get(k, 0) + v
+            return r.redacted
+        if isinstance(value, dict):
+            return {k: _walk(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_walk(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(_walk(v) for v in value)
+        return value
+
+    return _walk(data), counts

--- a/tests/test_secrets_redactor.py
+++ b/tests/test_secrets_redactor.py
@@ -1,0 +1,247 @@
+"""Tests for the secrets redactor (ghosthunter#3, v1.0.7).
+
+Covers all 8 credential pattern classes with positive (must redact)
+and negative (must NOT redact) cases. False negatives are unacceptable —
+a leaked credential persists on disk forever and can land in backups.
+False positives are tolerable; over-redaction in audit logs is fine.
+
+Also covers the recursive ``redact_dict`` helper used by the audit-log
+writer to walk nested entry structures.
+"""
+
+from __future__ import annotations
+
+from ghosthunter.security.secrets_redactor import (
+    SECRET_PATTERNS,
+    redact_dict,
+    redact_secrets,
+)
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — each pattern must fire
+# ---------------------------------------------------------------------------
+class TestAWSKeys:
+    def test_redacts_aws_access_key(self):
+        out = redact_secrets("found AKIAIOSFODNN7EXAMPLE in the env dump")
+        assert "AKIA" not in out.redacted
+        assert "[REDACTED:aws_access_key]" in out.redacted
+        assert out.redactions_by_pattern.get("aws_access_key") == 1
+
+    def test_redacts_aws_temp_access_key(self):
+        out = redact_secrets("session token: ASIAY34FZKBOKMUTVV7A")
+        assert "ASIA" not in out.redacted
+        assert "[REDACTED:aws_temp_access_key]" in out.redacted
+
+    def test_does_not_redact_short_akia_substring(self):
+        # Less than the 16-char body — not a real key.
+        out = redact_secrets("AKIASHORT")
+        assert out.redacted == "AKIASHORT"
+        assert not out.had_redactions
+
+
+class TestGitHubTokens:
+    def test_redacts_github_personal_access_token(self):
+        token = "ghp_" + "A" * 36
+        out = redact_secrets(f"GITHUB_TOKEN={token}")
+        assert "ghp_" not in out.redacted or "[REDACTED:github_token]" in out.redacted
+        assert out.redactions_by_pattern.get("github_token") == 1
+
+    def test_redacts_github_server_token(self):
+        token = "ghs_" + "B" * 36
+        out = redact_secrets(f"server token {token}")
+        assert "[REDACTED:github_token]" in out.redacted
+
+
+class TestAnthropicKeys:
+    def test_redacts_anthropic_api_key(self):
+        # Realistic anthropic key shape: sk-ant-<long alphanumeric>
+        key = "sk-ant-api03-abc123_def-456GHI789jkl"
+        out = redact_secrets(f"ANTHROPIC_API_KEY={key}")
+        assert "sk-ant-" not in out.redacted
+        assert "[REDACTED:anthropic_key]" in out.redacted
+
+
+class TestOpenAIKeys:
+    def test_redacts_openai_key(self):
+        key = "sk-" + "X" * 48
+        out = redact_secrets(f"export OPENAI_API_KEY={key}")
+        assert "[REDACTED:openai_key]" in out.redacted
+
+    def test_does_not_redact_short_sk_prefix(self):
+        # `sk-` followed by < 48 chars — not a real OpenAI key.
+        out = redact_secrets("sk-short")
+        assert out.redacted == "sk-short"
+
+
+class TestJWTs:
+    def test_redacts_jwt(self):
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        out = redact_secrets(f"Token: {jwt}")
+        assert "[REDACTED:jwt]" in out.redacted
+
+    def test_jwt_in_bearer_header_redacts_as_jwt_first(self):
+        # JWT pattern intentionally fires before bearer pattern.
+        jwt = "eyJhbGc.eyJzdWI.SflKxw"
+        out = redact_secrets(f"Authorization: Bearer {jwt}")
+        # Either jwt or bearer_token captures it — must not leak.
+        assert jwt not in out.redacted
+
+
+class TestBearerTokens:
+    def test_redacts_bearer_token(self):
+        out = redact_secrets("Authorization: Bearer abc123def456ghi789xyz")
+        assert "abc123def456ghi789xyz" not in out.redacted
+        assert "[REDACTED:bearer_token]" in out.redacted
+
+    def test_redacts_lowercase_bearer(self):
+        out = redact_secrets("authorization: bearer somelongtoken1234567890")
+        assert "[REDACTED:bearer_token]" in out.redacted
+
+
+class TestAuthHeaders:
+    def test_redacts_api_key_header(self):
+        out = redact_secrets('headers = {"x-api-key": "abcdef0123456789xyz"}')
+        assert "abcdef0123456789xyz" not in out.redacted
+        assert "[REDACTED:auth_header]" in out.redacted
+
+    def test_redacts_authorization_assignment(self):
+        out = redact_secrets("authorization=longsecrettoken1234567890")
+        assert "longsecrettoken" not in out.redacted
+
+
+class TestPEMPrivateKeys:
+    def test_redacts_pem_private_key(self):
+        pem = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            "MIIEpAIBAAKCAQEAfake_key_data_here_for_test_only\n"
+            "abcdef0123456789==\n"
+            "-----END RSA PRIVATE KEY-----"
+        )
+        out = redact_secrets(f"private_key was: {pem}")
+        assert "MIIEpAIBAAKCAQEA" not in out.redacted
+        assert (
+            "[REDACTED:pem_private_key]" in out.redacted
+            or "[REDACTED:gcp_private_key]" in out.redacted
+        )
+
+    def test_redacts_gcp_service_account_private_key(self):
+        # A typical GCP service account JSON shape with the private_key field.
+        text = (
+            '{"type":"service_account","project_id":"prj-x","'
+            'private_key":"-----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgk\\n'
+            '-----END PRIVATE KEY-----\\n","client_email":"sa@prj.iam.gserviceaccount.com"}'
+        )
+        out = redact_secrets(text)
+        assert "MIIEvQIBADAN" not in out.redacted
+        # client_email is NOT a secret, should remain.
+        assert "sa@prj.iam.gserviceaccount.com" in out.redacted
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — benign content must NOT trigger redaction
+# ---------------------------------------------------------------------------
+class TestNoFalsePositives:
+    def test_empty_string(self):
+        out = redact_secrets("")
+        assert out.redacted == ""
+        assert not out.had_redactions
+
+    def test_normal_billing_csv_row(self):
+        text = "2026-04-29,compute.googleapis.com,us-central1,$1234.56,$1100.00\n"
+        out = redact_secrets(text)
+        assert out.redacted == text
+        assert not out.had_redactions
+
+    def test_resource_id_with_alphanumerics(self):
+        # GCP resource IDs are long alphanumerics but don't have credential prefixes.
+        text = "instance: projects/my-prj/zones/us-central1-a/instances/web-server-001"
+        out = redact_secrets(text)
+        assert out.redacted == text
+        assert not out.had_redactions
+
+    def test_iam_member_email(self):
+        text = "iam_member: user:avinash@matrixgard.com"
+        out = redact_secrets(text)
+        assert out.redacted == text
+        assert not out.had_redactions
+
+    def test_uuid_does_not_match(self):
+        text = "request_id: 12345678-1234-1234-1234-123456789abc"
+        out = redact_secrets(text)
+        assert out.redacted == text
+        assert not out.had_redactions
+
+
+# ---------------------------------------------------------------------------
+# Multi-redaction
+# ---------------------------------------------------------------------------
+class TestMultipleSecrets:
+    def test_redacts_multiple_distinct_credentials(self):
+        text = (
+            "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n"
+            "GH_TOKEN=ghp_" + "Z" * 36 + "\n"
+            "Authorization: Bearer abcdefghijklmn1234567890\n"
+        )
+        out = redact_secrets(text)
+        assert out.total_redactions >= 3
+        assert "AKIA" not in out.redacted
+        assert "ghp_" not in out.redacted
+        assert "abcdefghijklmn1234567890" not in out.redacted
+
+
+# ---------------------------------------------------------------------------
+# redact_dict — the audit-log writer's helper
+# ---------------------------------------------------------------------------
+class TestRedactDict:
+    def test_redacts_string_values(self):
+        entry = {
+            "timestamp": "2026-04-30T05:00:00",
+            "conclusion": "Found AKIAIOSFODNN7EXAMPLE in env dump",
+            "succeeded": True,
+        }
+        out, counts = redact_dict(entry)
+        assert "AKIA" not in out["conclusion"]
+        assert out["timestamp"] == entry["timestamp"]
+        assert out["succeeded"] is True
+        assert counts.get("aws_access_key") == 1
+
+    def test_recursive_into_nested_dict(self):
+        entry = {
+            "extra": {
+                "raw_stdout": "Bearer abc123def456ghi789jkl0",
+            },
+        }
+        out, counts = redact_dict(entry)
+        assert "abc123def456ghi789jkl0" not in out["extra"]["raw_stdout"]
+        assert counts.get("bearer_token") == 1
+
+    def test_recursive_into_list(self):
+        entry = {"hypotheses": ["safe one", "AKIAIOSFODNN7EXAMPLE in here"]}
+        out, counts = redact_dict(entry)
+        assert "AKIA" not in out["hypotheses"][1]
+        assert out["hypotheses"][0] == "safe one"
+
+    def test_does_not_mutate_input(self):
+        entry = {"conclusion": "AKIAIOSFODNN7EXAMPLE leaked"}
+        original_value = entry["conclusion"]
+        out, _ = redact_dict(entry)
+        assert entry["conclusion"] == original_value  # unchanged
+        assert "[REDACTED:" in out["conclusion"]
+
+
+# ---------------------------------------------------------------------------
+# Pattern registry invariants
+# ---------------------------------------------------------------------------
+class TestPatternRegistry:
+    def test_at_least_8_patterns(self):
+        # Issue #3 specified 8 pattern classes minimum.
+        assert len(SECRET_PATTERNS) >= 8
+
+    def test_all_patterns_named_uniquely(self):
+        names = [name for name, _, _ in SECRET_PATTERNS]
+        assert len(names) == len(set(names)), "duplicate pattern names"
+
+    def test_all_replacements_have_redacted_marker(self):
+        for name, _pattern, replacement in SECRET_PATTERNS:
+            assert "REDACTED" in replacement, f"{name} replacement must mention REDACTED"


### PR DESCRIPTION
Closes #3.

The audit's only release-blocking finding. Three pieces:

1. **New `security/secrets_redactor.py`** — 9 pattern classes (AWS keys, GitHub tokens, Anthropic/OpenAI keys, JWTs, bearer tokens, auth headers, PEM/GCP private keys). Replace matches with `[REDACTED:<type>]`. JWT fires before bearer_token so `Bearer eyJ...` gets the specific label. `redact_dict()` recurses for nested entries.
2. **Wiring at all disk-write paths** — `_append_audit_log` redacts before `json.dump`. `palace.remember()` redacts content before storage. chat_history is prompt_toolkit-owned (out of our write path) — documented as known limitation.
3. **`ghosthunter purge-history` CLI** — wipes chat_history + audit.log + palace/ with y/N confirmation. `--yes` to skip. Migration path for users who pasted sensitive output under v1.0.6.

SECURITY.md item 2 updated with honest scope notes.

**Verification:**
- `pytest tests/test_secrets_redactor.py` → 29 passed
- `pytest tests/` → 1255 passed (zero regressions)
- ruff check + format → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)