### PR TITLE
release: v1.0.8 — security audit closure (#3, #4, #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,95 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-04-30
+
+### Security
+
+This release closes all four findings from an external security audit
+on 2026-04-29 (the day after v1.0.6 went public). Three landed as
+deterministic fixes; one was confirmed as by-design and documented.
+The full audit and gap ledger live at
+<https://matrixgard.com/docs/ghosthunter/security-review>.
+
+- **Secrets redacted before any disk write** ([#3]). Pasted command
+  output may contain credentials. Without redaction those secrets
+  persisted in `~/.ghosthunter/audit.log` and the memory palace
+  forever (and replicated via Time Machine, Dropbox, iCloud sync).
+  New module `ghosthunter.security.secrets_redactor` runs a 9-pattern
+  redaction over all on-disk writes — AWS access keys (AKIA / ASIA),
+  GitHub tokens (gh[psru]_), Anthropic / OpenAI API keys, JWTs (with
+  intentional ordering before bearer tokens), bearer tokens, generic
+  auth headers in shell / JSON / YAML forms, GCP service-account
+  `private_key` JSON fields, and standalone PEM-armored private keys.
+  Each match becomes `[REDACTED:<type>]`, preserving log structure.
+- **`ghosthunter purge-history` CLI command** ([#3]). Wipes
+  `~/.ghosthunter/chat_history`, `audit.log`, and `palace/` after a
+  y/N confirmation. `--yes` / `-y` skips the prompt. Migration path
+  for anyone who pasted sensitive output during v1.0.6 (no redaction
+  available then). Configuration files are preserved.
+- **Pre-prompt injection sanitizer + defensive prompt frame** ([#5]).
+  New module `ghosthunter.security.prompt_sanitizer` strips seven
+  known prompt-injection shapes ("ignore previous instructions",
+  role-redefinition phrases, `<system>` / `<admin>` / `<override>`
+  tags, "new instructions:" markers) from command output before the
+  prompt is built. Output is also wrapped in a `<command_output>`
+  defensive frame instructing Claude to treat the contents as
+  untrusted data, not instructions. Best-effort, not absolute — the
+  deterministic Layer 1–4 validator still holds regardless. This
+  defense exists to prevent misdirected investigations, not
+  security-boundary breaches.
+- **`awk` blocked in pipes** ([#4]). The previous safe-pipe regex
+  `^awk(\s+.+)?$` accepted any awk arguments, leaving awk's
+  `system()`, `getline`, and `exec()` builtins reachable in theory.
+  Removed awk from `SAFE_PIPE_TARGETS` and added it to
+  `BLOCKED_PIPE_TARGETS` (belt-and-braces — the blocklist check runs
+  before the safe-list check in `validate_pipes()`). GCP and AWS
+  reasoner prompts updated to drop `awk` from the listed safe pipes
+  so Claude doesn't propose awk pipes the validator then rejects.
+  No legitimate Ghost-hunter use case requires awk; `grep` / `cut` /
+  `jq` cover the same ground.
+- **Layer 6 approval-bias documented** (audit gap 4, by design).
+  Sonnet's semantic check defaults toward approval. The audit
+  confirmed this is intentional — Layer 2's static allowlist is the
+  deterministic gate; Layer 6 explains and double-checks.
+  `SECURITY.md` item 4 already covered this; no code change required.
+
+### Tests
+
+- **+158 security tests** (1097 → 1255 total). Five new awk-blocking
+  tests exercise the audit-flagged shapes (`system()`, `getline`,
+  `exec()` plus plain and bare awk). Twenty-six new tests for the
+  prompt sanitizer cover pattern hits, false-positive guards,
+  multi-pattern counting, the defensive wrapper, registry invariants,
+  and end-to-end integration with `_format_for_compression`.
+  Twenty-nine new tests for the secrets redactor cover all nine
+  credential classes, false-positive guards (resource IDs, IAM
+  emails, UUIDs, normal CSV rows), `redact_dict()` recursion, and
+  pattern-registry invariants.
+- **AWS test fixture strings replaced.** `AKIAIOSFODNN7EXAMPLE` and
+  `ASIAY34FZKBOKMUTVV7A` were AWS's published example keys — they
+  appeared in dozens of public repos' leak-fingerprint databases and
+  triggered GitHub Secret Scanning alerts on every fixture commit.
+  Replaced with synthetic strings (`AKIATESTFIXTUREXYZ12`,
+  `ASIATESTFIXTUREABC56`) that match the redactor regex shape but
+  aren't in any leak database.
+
+### Documentation
+
+- `SECURITY.md` items 1 ("Prompt injection via pasted output") and 2
+  ("Secrets in pasted output persist to disk") updated with v1.0.8
+  mitigation notes — honest about scope. The `chat_history` file is
+  prompt_toolkit-owned and remains outside our redaction path; this
+  is now explicit.
+- New website page <https://matrixgard.com/docs/ghosthunter/security-review>
+  publishes the audit verdict, the four documented gaps, and per-gap
+  fix tracking. Standing rule: every external review of Ghost-hunter
+  is published there in full, with auditor permission.
+
+[#3]: https://github.com/avinash-matrixgard/ghosthunter/issues/3
+[#4]: https://github.com/avinash-matrixgard/ghosthunter/issues/4
+[#5]: https://github.com/avinash-matrixgard/ghosthunter/issues/5
+
 ## [1.0.7] - 2026-04-28
 
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -111,7 +111,7 @@ please report it.
    waste your time and budget. Don't paste output from untrusted
    sources.
 
-   **Mitigation in v1.0.7:** the most common injection markers
+   **Mitigation in v1.0.8:** the most common injection markers
    ("ignore previous instructions", role-overrides, `<system>` /
    `<admin>` tags, "new instructions:", etc) are stripped from
    command output before the prompt is built (see
@@ -135,7 +135,7 @@ please report it.
    - `~/.ghosthunter/palace/` — if memory palace is enabled,
      conclusions are indexed.
 
-   **Mitigation in v1.0.7:** automatic redaction now runs on the
+   **Mitigation in v1.0.8:** automatic redaction now runs on the
    audit-log writer and the memory palace's `remember()` path before
    any disk write. Pattern-matched credential shapes (AWS access
    keys, GitHub tokens, Anthropic / OpenAI keys, JWTs, Bearer tokens,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ghosthunter"
-version = "1.0.7"
+version = "1.0.8"
 description = "Investigate WHY your cloud costs spiked — dual-model (Claude Opus + Sonnet) root-cause analysis for GCP and AWS."
 authors = ["MatrixGard <avinash@matrixgard.com>"]
 maintainers = ["MatrixGard <avinash@matrixgard.com>"]

--- a/src/ghosthunter/cli.py
+++ b/src/ghosthunter/cli.py
@@ -955,7 +955,7 @@ def purge_history(
 
     Use this if you ran v1.0.6 or earlier, pasted command output that may
     have contained secrets, and want to remove that history from disk. The
-    on-disk redaction layer was added in v1.0.7 (ghosthunter#3) — older
+    on-disk redaction layer was added in v1.0.8 (ghosthunter#3) — older
     history was written without redaction and may contain plaintext
     credentials.
 

--- a/src/ghosthunter/security/pipes.py
+++ b/src/ghosthunter/security/pipes.py
@@ -14,7 +14,7 @@ SAFE_PIPE_TARGETS: list[str] = [
     r"^tail(\s+-?\d+)?$",
     r"^grep(\s+-[ivEclnH]+)?(\s+.+)?$",
     r"^cut(\s+.+)?$",
-    # awk REMOVED in v1.0.7 — the previous pattern `^awk(\s+.+)?$` accepted
+    # awk REMOVED in v1.0.8 — the previous pattern `^awk(\s+.+)?$` accepted
     # any awk arguments, which left awk's `system()`, `getline`, and `exec()`
     # builtins reachable in theory. The Apr 29 2026 audit flagged this as a
     # theoretical-severity gap. Nothing in our investigator paths needs awk;
@@ -28,7 +28,7 @@ _COMPILED = [re.compile(p) for p in SAFE_PIPE_TARGETS]
 # Explicitly forbidden pipe targets — listed for clarity even though
 # anything not in SAFE_PIPE_TARGETS is rejected by default.
 #
-# `awk` is in this set as of v1.0.7. Belt-and-braces: even if a future
+# `awk` is in this set as of v1.0.8. Belt-and-braces: even if a future
 # contributor re-adds an awk pattern to SAFE_PIPE_TARGETS, the blocklist
 # check in validate_pipes() runs first and catches it.
 BLOCKED_PIPE_TARGETS = {

--- a/src/ghosthunter/security/prompt_sanitizer.py
+++ b/src/ghosthunter/security/prompt_sanitizer.py
@@ -15,7 +15,7 @@ This module is best-effort, not absolute. The patterns below cover the
 most common injection shapes; we wrap the output in a defensive
 ``<command_output>`` frame as a second layer.
 
-Added in v1.0.7 per ghosthunter#5 (Apr 29 2026 audit).
+Added in v1.0.8 per ghosthunter#5 (Apr 29 2026 audit).
 """
 
 from __future__ import annotations

--- a/src/ghosthunter/security/secrets_redactor.py
+++ b/src/ghosthunter/security/secrets_redactor.py
@@ -14,7 +14,7 @@ The user's mental model in paranoid mode is "Ghost-hunter is read-only and
 safe — I can paste freely" — so we have to make that assumption true at
 the disk-write layer.
 
-Added in v1.0.7 per ghosthunter#3 (Apr 29 2026 audit, the only release-
+Added in v1.0.8 per ghosthunter#3 (Apr 29 2026 audit, the only release-
 blocking finding among four documented gaps).
 
 Patterns target high-confidence credential shapes only. False positives

--- a/tests/test_prompt_sanitizer.py
+++ b/tests/test_prompt_sanitizer.py
@@ -1,4 +1,4 @@
-"""Tests for the pre-prompt injection sanitizer (ghosthunter#5, v1.0.7).
+"""Tests for the pre-prompt injection sanitizer (ghosthunter#5, v1.0.8).
 
 Pasted command output is untrusted. The sanitizer strips the most common
 prompt-injection shapes before the text reaches Claude. These tests are

--- a/tests/test_secrets_redactor.py
+++ b/tests/test_secrets_redactor.py
@@ -1,4 +1,4 @@
-"""Tests for the secrets redactor (ghosthunter#3, v1.0.7).
+"""Tests for the secrets redactor (ghosthunter#3, v1.0.8).
 
 Covers all 8 credential pattern classes with positive (must redact)
 and negative (must NOT redact) cases. False negatives are unacceptable —

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -291,10 +291,10 @@ class TestPipeValidation:
     def test_blocks_python_pipe(self, validator):
         assert not validator.is_allowed("gcloud compute instances list | python").allowed
 
-    # awk family — added in v1.0.7 per ghosthunter#4 (Apr 29 2026 audit).
+    # awk family — added in v1.0.8 per ghosthunter#4 (Apr 29 2026 audit).
     # Previously `^awk(\s+.+)?$` accepted awk with any args, which left
     # awk's `system()` / `getline` / `exec()` builtins reachable in theory.
-    # Since v1.0.7 awk is in BLOCKED_PIPE_TARGETS — closes the entire
+    # Since v1.0.8 awk is in BLOCKED_PIPE_TARGETS — closes the entire
     # surface in one move.
     def test_blocks_plain_awk_pipe(self, validator):
         assert not validator.is_allowed("gcloud compute instances list | awk '{print $1}'").allowed


### PR DESCRIPTION
v1.0.7 was already published to PyPI (the AGPL relicense from Apr 28). Audit-fix release rolls forward to **v1.0.8**.

**Changes:**
- `pyproject.toml`: 1.0.7 → 1.0.8
- All inline source/test/SECURITY.md references to v1.0.7 rewritten to v1.0.8
- New `[1.0.8]` section in CHANGELOG.md cross-referencing issues #3 / #4 / #5 + the website security-review page

**Verification:**
- `pytest tests/` → 1255 passed
- `ruff check + format` → clean

After this merges, you can: tag `v1.0.8`, GitHub Release with the changelog excerpt, `poetry build && poetry publish` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)